### PR TITLE
Additional key checks for browser compatibility

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/modal_root.jsx
+++ b/app/assets/javascripts/components/features/ui/components/modal_root.jsx
@@ -22,7 +22,8 @@ class ModalRoot extends React.PureComponent {
   }
 
   handleKeyUp (e) {
-    if (e.key === 'Escape' && !!this.props.type) {
+    if ((e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27)
+         && !!this.props.type) {
       this.props.onClose();
     }
   }


### PR DESCRIPTION
Not all browsers recognize e.key === 'Escape'; some use 'Esc' and some only respond to the keyCode.